### PR TITLE
Add new `/experiment_user_trials/convert` endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,26 @@ experiment.record_conversion(user)
 Calling `#record_conversion` will create a trial for that user if one doesn't already exist. There is a unique database constraint limiting users to a single
 trial per experiment.
 
-Or via JavaScript:
+Record a trial via JavaScript:
 ```javascript
 $.post(
   '/hyp/experiment_user_trials',
   { experiment_name: 'My Very First Experiment', user_identifier: 1 },
-  function(data, status, _xhr) { console.log("Status: %s\nData: %s", status, data); }
+  function(data, status, _xhr) {
+    console.log("Status: %s\nData: %s", status, data);
+  }
+);
+```
+
+Record a conversion via JavaScript:
+```javascript
+$.ajax(
+  url: '/hyp/experiment_user_trials/convert',
+  type: 'PATCH',
+  data: { experiment_name: 'My Very First Experiment', user_identifier: 1 },
+  success: function(data, status, _xhr) {
+    console.log("Status: %s\nData: %s", status, data);
+  }
 );
 ```
 

--- a/app/controllers/hyp/experiment_user_trials_controller.rb
+++ b/app/controllers/hyp/experiment_user_trials_controller.rb
@@ -20,7 +20,7 @@ module Hyp
       end
     end
 
-    def update
+    def convert
       respond_to do |format|
         format.json do
           if @experiment.record_conversion(@user)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Hyp::Engine.routes.draw do
-  resources :experiment_user_trials, only: %i[create update]
+  resources :experiment_user_trials, only: %i[create] do
+    collection do
+      patch :convert
+    end
+  end
   resources :experiments
   resource  :sample_size, only: %i[show]
 end

--- a/spec/dummy/spec/controllers/hyp_experiment_user_trials_controller_spec.rb
+++ b/spec/dummy/spec/controllers/hyp_experiment_user_trials_controller_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Hyp::ExperimentUserTrialsController, controller: true do
+  routes { Hyp::Engine.routes }
+
+  let!(:exp) do
+    Hyp::ExperimentRepo.create(
+      alpha: 0.05,
+      power: 0.80,
+      control: 0.05,
+      minimum_detectable_effect: 0.05,
+      name: "Baby's first experiment"
+    )
+  end
+
+  let(:idiot) do
+    Idiot.create!(name: 'Dan', age: 29)
+  end
+
+  describe 'POST #create via AJAX' do
+    it 'creates a unique `ExperimentUserTrial` for the user' do
+      expect {
+        post :create,
+          format: :json,
+          params: {
+            experiment_name: exp.name,
+            user_identifier: idiot.id
+          }
+      }.to change { Hyp::ExperimentUserTrial.count }.by(1)
+
+      expect {
+        post :create,
+          format: :json,
+          params: {
+            experiment_name: exp.name,
+            user_identifier: idiot.id
+          }
+      }.not_to change { Hyp::ExperimentUserTrial.count }
+    end
+  end
+
+  describe 'PATCH #convert via AJAX' do
+    let(:trial) do
+      Hyp::ExperimentUserTrial.create!(
+        experiment: exp,
+        variant: exp.control_variant,
+        user: idiot
+      )
+    end
+
+    it 'marks an `ExperimentUserTrial` as converted' do
+      expect {
+        patch :convert,
+          format: :json,
+          params: {
+            experiment_name: exp.name,
+            user_identifier: idiot.id
+          }
+      }.to change { trial.reload && trial.converted? }.from(false).to(true)
+    end
+  end
+end


### PR DESCRIPTION
So it's possible to record conversions via AJAX.