### PR TITLE
More precise experiment progress percentage.

### DIFF
--- a/app/models/hyp/experiment_helpers/methods.rb
+++ b/app/models/hyp/experiment_helpers/methods.rb
@@ -51,7 +51,7 @@ module Hyp
       def progress
         @progress ||= (
           variants.sum { |v| num_trials(v) } / (sample_size * variants.count.to_f)
-        ).round(2)
+        ).round(4)
       end
 
       def control_conversion_rate

--- a/spec/dummy/spec/models/hyp_experiment_spec.rb
+++ b/spec/dummy/spec/models/hyp_experiment_spec.rb
@@ -189,7 +189,7 @@ describe Hyp::Experiment do
         end
 
         it 'returns the percentage of the required number of trials that have been required' do
-          expect(subject.progress).to be 0.01
+          expect(subject.progress).to be 0.0105
         end
       end
     end


### PR DESCRIPTION
Round to 4 decimal places rather than 2 before converting decimal to percentage when calculating experiment progress.

This ensures we don't erroneously round up to 1.0 (100%) when we're actually at something like 0.9968 (99.68%).